### PR TITLE
Add keyboardShouldPersistTaps to FilterList ListView

### DIFF
--- a/src/components/FilterList.js
+++ b/src/components/FilterList.js
@@ -83,6 +83,7 @@ export class FilterList extends Component {
         )}
         {foundResults && (
           <ListView
+            keyboardShouldPersistTaps
             dataSource={this.dataSource.cloneWithRows(filteredContents)}
             renderRow={
               content => <ContentRow {...content} onSelect={this.props.onSelect} />


### PR DESCRIPTION
Fix needing double tap issue, keyboard can still be dismissed (on android) with back button