### PR TITLE
Convert React PropTypes to prop-types module

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "apsl-react-native-button": "^3.0.2",
     "lodash": "^4.13.1",
+    "prop-types": "^15.5.10",
     "react": "16.0.0-alpha.6",
     "react-native": "^0.44.0",
     "react-native-alphabetlistview": "^0.2.0",

--- a/src/components/Connection.js
+++ b/src/components/Connection.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import {
   AsyncStorage,
   StyleSheet,

--- a/src/components/ContentRow.js
+++ b/src/components/ContentRow.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { PixelRatio, StyleSheet, Text, TouchableNativeFeedback, View } from 'react-native'
 
 const styles = StyleSheet.create({

--- a/src/components/ContentsList.js
+++ b/src/components/ContentsList.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import { ListView, StyleSheet, Text, View } from 'react-native'
 
 import { ContentRow } from './ContentRow'

--- a/src/components/FilterList.js
+++ b/src/components/FilterList.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { ListView, StyleSheet, Text, TextInput, View } from 'react-native'
 
 import { ContentRow } from './ContentRow'

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { Alert, BackHandler, ToastAndroid } from 'react-native'
 import Drawer from 'react-native-drawer'
 import { uniq } from 'lodash'

--- a/src/components/HomeHeader.js
+++ b/src/components/HomeHeader.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { StyleSheet, Text, TouchableHighlight, View } from 'react-native'
 import Icon from 'react-native-vector-icons/EvilIcons'
 

--- a/src/components/HomeListView.js
+++ b/src/components/HomeListView.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import AlphabetListView from 'react-native-alphabetlistview'
 
 import { HomeRow } from './HomeRow'

--- a/src/components/HomeRow.js
+++ b/src/components/HomeRow.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import {
   StyleSheet,
   Text,

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import {
   ScrollView,
   StyleSheet,

--- a/src/components/MenuItem.js
+++ b/src/components/MenuItem.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import {
   StyleSheet,
   Text,

--- a/src/components/Playlist.js
+++ b/src/components/Playlist.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { StyleSheet, View } from 'react-native'
 import Button from 'apsl-react-native-button'
 import { ContentsList } from './ContentsList'

--- a/src/components/PlaylistStatusBar.js
+++ b/src/components/PlaylistStatusBar.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import {
   StyleSheet,
   Text,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2782,7 +2782,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.8:
+prop-types@^15.5.10, prop-types@^15.5.8:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:


### PR DESCRIPTION
(Tweaked output from [React-PropTypes-to-prop-types react-codemod](https://github.com/reactjs/react-codemod#react-proptypes-to-prop-types))