### PR TITLE
Show a language flag when possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-native": "0.45.0",
     "react-native-alphabetlistview": "^0.2.0",
     "react-native-drawer": "^2.2.3",
+    "react-native-flags": "^1.0.0",
     "react-native-vector-icons": "^4.1.1",
     "react-navigation": "^1.0.0-beta.11",
     "react-redux": "^5.0.5",

--- a/src/components/ContentRow.js
+++ b/src/components/ContentRow.js
@@ -1,18 +1,34 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import { PixelRatio, StyleSheet, Text, TouchableNativeFeedback, View } from 'react-native'
+import Flag from 'react-native-flags'
+
+const languageCodes = {
+  eng: 'US',
+  fre: 'FR',
+  rus: 'RU',
+  deu: 'DE',
+  ita: 'IT',
+  esp: 'ES',
+  jpn: 'JP',
+  swe: 'SE',
+  kor: 'KR',
+}
 
 const styles = StyleSheet.create({
   row: {
     padding: 10,
     flex: 1,
-    flexDirection: 'column',
-    alignItems: 'stretch',
+    flexDirection: 'row',
+    alignItems: 'center',
     borderBottomWidth: 1 / PixelRatio.get(),
   },
   rowText: {
     fontSize: 16,
     color: '#D9E4D7',
+  },
+  flagContainer: {
+    width: 32,
   },
 })
 
@@ -21,12 +37,14 @@ export default class ContentRow extends PureComponent {
     group: PropTypes.string.isRequired,
     hideGroup: PropTypes.bool,
     id: PropTypes.string.isRequired,
+    language: PropTypes.string,
     onSelect: PropTypes.func,
     songName: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
   }
 
   static defaultProps = {
+    language: '',
     hideGroup: false,
     onSelect: () => {},
   }
@@ -36,10 +54,14 @@ export default class ContentRow extends PureComponent {
   }
 
   render() {
-    const { group, hideGroup, songName, type } = this.props
+    const { group, hideGroup, language, songName, type } = this.props
+
     return (
       <TouchableNativeFeedback onPress={this.onPress}>
         <View style={styles.row}>
+          <View style={styles.flagContainer}>
+            <Flag code={languageCodes[language] || 'unknown'} size={24} type="flat" />
+          </View>
           <Text style={styles.rowText}>
             {!hideGroup && `${group} - `}
             {type} - {songName}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3057,6 +3057,10 @@ react-native-drawer@^2.2.3:
   dependencies:
     tween-functions "^1.0.1"
 
+react-native-flags@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-flags/-/react-native-flags-1.0.0.tgz#8bf99b58e125ca6057d7923549132b3579754ed3"
+
 react-native-tab-view@^0.0.65:
   version "0.0.65"
   resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-0.0.65.tgz#b685ea3081ff7c96486cd997361026c407302c59"


### PR DESCRIPTION
![screenshot_1502555806](https://user-images.githubusercontent.com/1598317/29242491-a8b7c2cc-7f8e-11e7-88c3-9c7275532b7f.png)

This will allow us to avoid terrible mistakes, like choosing the first Pegasus Fantasy on this screenshot

Fix #52