### PR TITLE
fix prettier script at precommit

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
-    "precommit": "prettier --write src/**/*.js"
+    "precommit": "./.prettier.sh"
   },
   "dependencies": {
     "eslint-config-prettier": "^2.4.0",
@@ -30,6 +30,6 @@
     "eslint-plugin-jsx-a11y": "^5.0.3",
     "eslint-plugin-react": "^7.0.1",
     "husky": "^0.13.4",
-    "prettier": "^1.6.1"
+    "prettier": "1.11.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3331,9 +3331,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.6.1.tgz#850f411a3116226193e32ea5acfc21c0f9a76d7d"
+prettier@1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.11.1.tgz#61e43fc4cd44e68f2b0dfc2c38cd4bb0fccdcc75"
 
 pretty-format@^4.2.1:
   version "4.3.1"


### PR DESCRIPTION
I apparently removed the precommit script [a few months ago](https://github.com/codeheroics/karakuri-mobile/commit/f8d97d26df604bdaaed4c4f6d816f6ddee245661) and I think it may have been a mistake I made while debugging, since the current precommit setup was fixing files with prettier, but not preventing the commit, which has led me to multiples cases of "but why wasn't this committed?" before I figured it out